### PR TITLE
feat(auth): implement sign up API route

### DIFF
--- a/app/api/auth/sign-up/route.ts
+++ b/app/api/auth/sign-up/route.ts
@@ -1,0 +1,69 @@
+/* O objetivo deste arquivo: Receber um email e senha do formulário, verificar se são válidos, e criar um novo usuário no banco.*/
+
+import { NextRequest, NextResponse } from 'next/server';
+import bcrypt from 'bcrypt' // Criptografar a senha
+import { prisma } from '@/lib/prisma' // Client do Prisma 
+
+// Função para a rota POST (Cadastro)
+export async function POST(request: NextRequest) {
+  try {
+    // 1. Recebe e valida o corpo da requisição 
+    const body = await request.json()
+    const { email, password } = body
+
+    if (!email || !password) {
+      return NextResponse.json(
+        { error: 'Email e senha são obrigatórios.'}, 
+        { status: 400}, // 400 = Bad request
+      )
+    }
+
+    if (password.length < 6 ) {
+      return NextResponse.json(
+        { error: 'Senha deve ter no mínimo 6 caracteres.' }, 
+        { status: 400 }, 
+      )
+    }
+
+    // 2. Verifica se o usuário (email) já existe no banco
+    const existingUser = await prisma.user.findUnique({
+      where: {email: email}, 
+    })
+
+    if (existingUser) {
+      return NextResponse.json(
+        { error: 'Este e-mail já está em uso.' }, 
+        { status: 409 }, // 409 - Conflict
+      )
+    }
+
+    // 3. Criptografa a senha (NUNCA salvar senhas em texto puro)
+    // O '10' é o "salt round", um bom padrão de segurança. 
+    const hashedPassword = await bcrypt.hash(password, 10)
+
+    // 4. Cria o novo usuário no banco de dados
+    const newUser = await prisma.user.create({
+      data: {
+        email: email,
+        hashedPassword: hashedPassword,
+        // O Prisma preenche automaticamente os campos default: id, plan, createdAt, etc.
+      },
+    })
+
+    // 5. Retorna uma resposta de sucesso 
+    return NextResponse.json(
+      {
+        meessage: 'Usuário criado com sucesso!', 
+        userId: newUser.id,
+        email: newUser.email,
+      },
+      { status: 201 }, //201 = Created
+    )
+  } catch (error) {
+    console.log('Erro no cadastro:', error)
+    return NextResponse.json(
+      { error: 'Erro interno do servidor.' },
+      { status: 500 }, 
+    )
+  }
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,19 @@
+import { PrismaClient } from '@prisma/client'
+
+//Declara uma variável global para "guardar" o client do Prisma
+// Isso evita criar mútiplas conexões em ambiente de desenvolvimento (com o "hot reload")
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined
+}
+
+// Criação client Prisma 
+
+export const prisma = 
+  globalForPrisma.prisma ?? 
+  new PrismaClient({
+    log: ['query', 'info', 'warn', 'error' ] // loga todas as queries no terminal
+  })
+
+  // Se não estamos em produção, armazena a conexão global 
+
+  if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^6.18.0",
+        "bcrypt": "^6.0.0",
         "next": "16.0.1",
         "react": "19.2.0",
         "react-dom": "19.2.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/bcrypt": "^6.0.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1583,6 +1585,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2505,6 +2517,20 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/brace-expansion": {
@@ -5321,12 +5347,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.27",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
   },
   "dependencies": {
     "@prisma/client": "^6.18.0",
+    "bcrypt": "^6.0.0",
     "next": "16.0.1",
     "react": "19.2.0",
     "react-dom": "19.2.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/bcrypt": "^6.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,8 +23,8 @@ model User {
 
   // Colunas para o SaaS (Stripe)
   plan                  String    @default("FREE")
-  stripeCustomerId      String    @unique // ID do cliente no Stripe 
-  stripeSubscriptionId  String    @unique // ID de assinatura 
+  stripeCustomerId      String?    @unique // ID do cliente no Stripe 
+  stripeSubscriptionId  String?  @unique // ID de assinatura 
   stripeSubscriptionEndsAt   DateTime? // Data que a assinatura PRO expira 
 
   createdAt DateTime @default(now())


### PR DESCRIPTION
Cria a rota de API (POST /api/auth/sign-up) para o cadastro de novos usuários.

- Instala `bcrypt` para hash de senha.
- Adiciona `lib/prisma.ts` (Singleton) para conexão com o banco.
- Implementa validação de dados e criação de usuário no banco.
- Corrige campos opcionais do Stripe no `schema.prisma`.

Closes #8